### PR TITLE
Addition of Japanese localization

### DIFF
--- a/Silicon.xcodeproj/project.pbxproj
+++ b/Silicon.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		0586D6202566CED200CBBD48 /* DropView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropView.swift; sourceTree = "<group>"; };
 		05F025522575FF1200ADB3EA /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/MainWindowController.strings"; sourceTree = "<group>"; };
 		05F025562575FF1A00ADB3EA /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/MainWindowController.strings"; sourceTree = "<group>"; };
+		F6F9B883288D3A98002AB990 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/MainWindowController.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -383,6 +384,7 @@
 				Base,
 				"zh-Hans",
 				"zh-HK",
+				ja,
 			);
 			mainGroup = 0586D53E256696D900CBBD48;
 			productRefGroup = 0586D548256696D900CBBD48 /* Products */;
@@ -503,6 +505,7 @@
 			children = (
 				05F025522575FF1200ADB3EA /* zh-Hans */,
 				05F025562575FF1A00ADB3EA /* zh-HK */,
+				F6F9B883288D3A98002AB990 /* ja */,
 			);
 			name = MainWindowController.strings;
 			sourceTree = "<group>";

--- a/Silicon/UI/ja.lproj/MainWindowController.strings
+++ b/Silicon/UI/ja.lproj/MainWindowController.strings
@@ -1,0 +1,35 @@
+/* Class = "NSWindow"; title = "Silicon"; ObjectID = "4ss-uf-DBv"; */
+"4ss-uf-DBv.title" = "Silicon";
+
+/* Class = "NSTextFieldCell"; title = "You can also drop an application here to verify it."; ObjectID = "9uz-mz-Can"; */
+"9uz-mz-Can.title" = "個別のアプリをここにドラックアンドドロップして確認できます。";
+
+/* Class = "NSTextFieldCell"; title = "Identify Intel-Only Apps on your Mac"; ObjectID = "DFM-dV-koX"; */
+"DFM-dV-koX.title" = "Mac内のIntel用アプリを判別する";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Reveal in Finder"; ObjectID = "GPh-5t-rfW"; */
+"GPh-5t-rfW.ibShadowedToolTip" = "Finderで表示";
+
+/* Class = "NSButtonCell"; title = "Recurse into Applications"; ObjectID = "HUW-pw-w0O"; */
+"HUW-pw-w0O.title" = "アプリ内の要素もスキャン対象に含む";
+
+/* Class = "NSButtonCell"; title = "Start Scanning"; ObjectID = "MEb-Ef-ukk"; */
+"MEb-Ef-ukk.title" = "スキャンを開始";
+
+/* Class = "NSTextFieldCell"; title = "Applications Found:"; ObjectID = "MJD-Yn-xAC"; */
+"MJD-Yn-xAC.title" = "見つかったアプリ:";
+
+/* Class = "NSMenuItem"; title = "Show All Apps"; ObjectID = "QoR-x6-4UR"; */
+"QoR-x6-4UR.title" = "すべてのアプリケーションを表示";
+
+/* Class = "NSButtonCell"; title = "Only Scan the Applications Folder"; ObjectID = "b2W-HI-GII"; */
+"b2W-HI-GII.title" = "アプリケーションフォルダのみスキャンする";
+
+/* Class = "NSButtonCell"; title = "Exclude Apple Applications"; ObjectID = "d0l-gf-yml"; */
+"d0l-gf-yml.title" = "Apple純正アプリを除く";
+
+/* Class = "NSMenuItem"; title = "Show Apple SIlicon Compatible Apps"; ObjectID = "uJw-yo-gLb"; */
+"uJw-yo-gLb.title" = "Appleシリコンに最適化されたアプリを表示";
+
+/* Class = "NSMenuItem"; title = "Show Intel-Only Apps"; ObjectID = "ux4-9b-ut4"; */
+"ux4-9b-ut4.title" = "Intel用アプリを表示";


### PR DESCRIPTION
I learned about this application from a Japanese web media article. This time, we localized the Japanese language as well as other languages. The changes are as follows.

Addition of Japanese localization
Only the parts that were localized in other languages were localized. This means that the window portion of the application will be written in Japanese.

Point of concern
Whereas in English it is written as a one-byte ":", in Chinese it is written as "：". In Japanese, too, the front angle is used, but in Apple's genuine apps, it is half-width notation, so I think it is better to match this. This correction is not included in this issue.